### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -1,5 +1,8 @@
 name: Scheduled Terraform Test
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: "0 0 * * *" # Runs every day at midnight UTC


### PR DESCRIPTION
Potential fix for [https://github.com/locus313/terraform-module-aws-route53/security/code-scanning/1](https://github.com/locus313/terraform-module-aws-route53/security/code-scanning/1)

The best way to fix the problem is to explicitly set the `permissions` key at the workflow level (at the top, before the `jobs` key), which will apply the least privileged permissions to all jobs unless overridden. Since the jobs in this workflow only require access to check out code (which only needs `contents: read`) and do not perform any repository-write actions, the minimal required permissions should be `contents: read`. This can be accomplished by adding the following block right after the workflow `name` and before the `on:` key:

```yaml
permissions:
  contents: read
```

There is no need to set job-level permissions unless a specific job requires broader permissions, which is not the case here. No imports or additional definitions are needed; just this change to the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
