### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Terraform Lint
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/locus313/terraform-module-aws-route53/security/code-scanning/2](https://github.com/locus313/terraform-module-aws-route53/security/code-scanning/2)

The solution is to add an explicit `permissions` field to the workflow to restrict the permissions granted to the `GITHUB_TOKEN`. This can be done at the root level of the workflow or for individual jobs. In this specific case, since the workflow is used for Terraform linting tasks, the `contents: read` permission is sufficient. This permission enables the workflow to read repository contents while preventing write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
