### PR TITLE
Add policy to deny non-HTTPS requests to S3 bucket

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -50,6 +50,23 @@ resource "aws_s3_bucket_policy" "records_wr" {
             "aws:SourceArn" = aws_cloudfront_distribution.records_wr[each.key].arn
           }
         }
+      },
+      {
+        # Deny all non-HTTPS requests to the bucket (satisfies HTTPS-only transit requirements).
+        # CloudFront OAC always communicates with S3 over HTTPS, so this never blocks legitimate access.
+        Sid       = "DenyNonHTTPS"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.records_wr[each.key].arn,
+          "${aws_s3_bucket.records_wr[each.key].arn}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
       }
     ]
   })


### PR DESCRIPTION
This pull request introduces an important security enhancement to the S3 bucket policy for the `records_wr` resources. The main change is the addition of a policy statement that explicitly denies all non-HTTPS requests to the bucket, ensuring compliance with HTTPS-only transit requirements.

**Security improvements:**

* Added a new statement to the S3 bucket policy (`aws_s3_bucket_policy.records_wr`) that denies all non-HTTPS requests by checking the `aws:SecureTransport` condition. This ensures only HTTPS traffic is allowed, aligning with best practices and compliance requirements.